### PR TITLE
Fix sequencial producer queue stream buffer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies._
 
-lazy val akkaVersion = "2.5.4"
+lazy val akkaVersion = "2.5.6"
 
 lazy val TestAndIntegration = s"it,${Test}"
 
@@ -11,25 +11,24 @@ lazy val root = (project in file(".")).
     inThisBuild(List(
       organization := "com.taxis99",
       scalaVersion := "2.12.3",
-      version      := "0.3.3"
+      version      := "0.3.4"
     )),
     name := "common-sqs",
     licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
     crossScalaVersions := Seq("2.11.11", "2.12.3"),
     libraryDependencies ++= Seq(
       "javax.inject"       % "javax.inject"             % "1",
-      "com.amazonaws"      % "aws-java-sdk-sqs"         % "1.11.172",
+      "com.amazonaws"      % "aws-java-sdk-sqs"         % "1.11.225",
       "com.typesafe"       % "config"                   % "1.3.1" % Provided,
       "com.typesafe.play"  %% "play-json"               % "2.6.2" % Provided,
-      "com.lightbend.akka" %% "akka-stream-alpakka-sns" % "0.11",
-      "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % "0.11",
+      "com.lightbend.akka" %% "akka-stream-alpakka-sns" % "0.14",
+      "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % "0.14",
       "com.github.xuwei-k" %% "msgpack4z-core"          % "0.3.7",
       "com.github.xuwei-k" %% "msgpack4z-play"          % "0.5.1",
       "com.github.xuwei-k" %% "msgpack4z-native"        % "0.3.3",
       "org.elasticmq"      %% "elasticmq-server"        % "0.13.8",
-      "com.iheart"         %% "ficus"                   % "1.4.1",
       "com.typesafe.akka"  %% "akka-stream"             % akkaVersion,
-      "com.typesafe.akka"  %% "akka-stream-testkit"     % akkaVersion,
+      "com.typesafe.akka"  %% "akka-stream-testkit"     % akkaVersion % TestAndIntegration,
       "com.typesafe.akka"  %% "akka-testkit"            % akkaVersion % TestAndIntegration,
       scalaTest % TestAndIntegration
     ),

--- a/src/it/scala/SnsSpec.scala
+++ b/src/it/scala/SnsSpec.scala
@@ -1,7 +1,7 @@
 import akka.testkit.TestProbe
 import com.taxis99.amazon.sns.SnsClient
 import com.taxis99.amazon.sqs.SqsClient
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import it.IntegrationSpec
 import it.mocks.{TestConsumer, TestPublisher, TestType}
 
@@ -14,10 +14,14 @@ import scala.concurrent.duration._
   */
 class SnsSpec extends IntegrationSpec {
 
-  val config = ConfigFactory.parseMap(Map(
+  val config: Config = ConfigFactory.parseMap(Map[String, String](
     "sns.topic" -> "integration-test-topic",
     "sqs.q1" -> "sns-test-q-1",
-    "sqs.q2" -> "sns-test-q-2"
+    "sqs.q2" -> "sns-test-q-2",
+    s"sqs.settings.default.waitTimeSeconds" -> "20",
+    s"sqs.settings.default.maxBufferSize" -> "100",
+    s"sqs.settings.default.maxBatchSize" -> "10",
+    s"sqs.settings.default.maxRetries" -> "200"
   ).asJava)
 
   implicit val sqs = new SqsClient(config)

--- a/src/it/scala/SqsSpec.scala
+++ b/src/it/scala/SqsSpec.scala
@@ -1,22 +1,23 @@
 package com.taxis99.amazon.sqs
 
 import akka.testkit.TestProbe
-import com.amazonaws.handlers.AsyncHandler
-import com.amazonaws.services.sqs.model.{SendMessageRequest, SendMessageResult}
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import it.IntegrationSpec
 import it.mocks.{TestConsumer, TestProducer, TestType}
 
 import scala.collection.JavaConverters._
-import scala.concurrent.Promise
 import scala.concurrent.duration._
 
 class SqsSpec extends IntegrationSpec {
 
   val queueName = "integration-test-q"
-  val config = ConfigFactory.parseMap(Map[String, String](
-      s"sqs.$queueName" -> queueName
-    ).asJava)
+  val config: Config = ConfigFactory.parseMap(Map[String, String](
+    s"sqs.$queueName" -> queueName,
+    s"sqs.settings.default.waitTimeSeconds" -> "20",
+    s"sqs.settings.default.maxBufferSize" -> "100",
+    s"sqs.settings.default.maxBatchSize" -> "10",
+    s"sqs.settings.default.maxRetries" -> "200"
+  ).asJava)
 
   implicit val sqs = new SqsClient(config)
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,6 @@
+sqs.settings.default {
+  waitTimeSeconds = 20
+  maxBufferSize   = 100
+  maxBatchSize    = 10
+  maxRetries      = 200
+}

--- a/src/main/scala/com/taxis99/amazon/sns/SnsClient.scala
+++ b/src/main/scala/com/taxis99/amazon/sns/SnsClient.scala
@@ -12,7 +12,8 @@ import com.amazonaws.services.sns.AmazonSNSAsync
 import com.amazonaws.services.sns.model.{CreateTopicRequest, CreateTopicResult}
 import com.taxis99.amazon.serializers.ISerializer
 import com.taxis99.amazon.streams.Producer
-import com.typesafe.config.{Config, ConfigFactory}
+import com.taxis99.implicits.DISABLE_BUFFER
+import com.typesafe.config.Config
 import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory
 import play.api.libs.json.JsValue
@@ -77,6 +78,6 @@ class SnsClient @Inject()(config: Config)
     eventualTopicConfig map { t =>
       val flow = SnsFlow.flow(t.arn)
       logger.info(s"Start producer for ${t.arn}")
-      Source.queue[(JsValue, Promise[Done])](0, OverflowStrategy.backpressure).async to Producer.sns(flow) run()
+      Source.queue[(JsValue, Promise[Done])](DISABLE_BUFFER, OverflowStrategy.backpressure).async to Producer.sns(flow) run()
     }
 }

--- a/src/main/scala/com/taxis99/amazon/sns/SnsClient.scala
+++ b/src/main/scala/com/taxis99/amazon/sns/SnsClient.scala
@@ -12,7 +12,7 @@ import com.amazonaws.services.sns.AmazonSNSAsync
 import com.amazonaws.services.sns.model.{CreateTopicRequest, CreateTopicResult}
 import com.taxis99.amazon.serializers.ISerializer
 import com.taxis99.amazon.streams.Producer
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory
 import play.api.libs.json.JsValue
@@ -76,6 +76,7 @@ class SnsClient @Inject()(config: Config)
                (implicit serializer: ISerializer): Future[SourceQueueWithComplete[(JsValue, Promise[Done])]] =
     eventualTopicConfig map { t =>
       val flow = SnsFlow.flow(t.arn)
-      Source.queue[(JsValue, Promise[Done])](0, OverflowStrategy.backpressure) to Producer.sns(flow) run()
+      logger.info(s"Start producer for ${t.arn}")
+      Source.queue[(JsValue, Promise[Done])](0, OverflowStrategy.backpressure).async to Producer.sns(flow) run()
     }
 }

--- a/src/main/scala/com/taxis99/amazon/sqs/SqsClient.scala
+++ b/src/main/scala/com/taxis99/amazon/sqs/SqsClient.scala
@@ -4,23 +4,23 @@ import javax.inject._
 
 import akka.Done
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings, OverflowStrategy, Supervision}
-import akka.stream.alpakka.sqs.scaladsl.{SqsAckSink, SqsFlow, SqsSink, SqsSource}
+import akka.stream.alpakka.sqs.scaladsl.{SqsAckSink, SqsFlow, SqsSource}
 import akka.stream.alpakka.sqs.{All, MessageAttributeName, SqsSourceSettings}
 import akka.stream.scaladsl.{Source, SourceQueueWithComplete}
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings, OverflowStrategy, Supervision}
 import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model.{GetQueueUrlRequest, GetQueueUrlResult}
 import com.taxis99.amazon.serializers.ISerializer
 import com.taxis99.amazon.streams.{Consumer, Producer}
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.Logger
-import net.ceedubs.ficus.Ficus._
 import org.slf4j.LoggerFactory
 import play.api.libs.json.JsValue
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.Try
 
 /**
   * The SQS client provides an abstraction to interact with Amazon SQS queues through Akka Stream. The client is
@@ -46,10 +46,10 @@ class SqsClient @Inject()(config: Config)
 
   implicit val materializer = ActorMaterializer(settings)
 
-  private val defaultWaitTimeSeconds = config.as[Option[Int]]("sqs.settings.default.waitTimeSeconds").getOrElse(20)
-  private val defaultMaxBufferSize = config.as[Option[Int]]("sqs.settings.default.maxBufferSize").getOrElse(100)
-  private val defaultMaxBatchSize = config.as[Option[Int]]("sqs.settings.default.maxBatchSize").getOrElse(10)
-  private val defaultMaxRetries = config.as[Option[Int]]("sqs.settings.default.maxRetries").getOrElse(200)
+  private val defaultWaitTimeSeconds = config.getInt("sqs.settings.default.waitTimeSeconds")
+  private val defaultMaxBufferSize = config.getInt("sqs.settings.default.maxBufferSize")
+  private val defaultMaxBatchSize = config.getInt("sqs.settings.default.maxBatchSize")
+  private val defaultMaxRetries = config.getInt("sqs.settings.default.maxRetries")
 
   logger.info("SQS Client ready")
 
@@ -87,10 +87,10 @@ class SqsClient @Inject()(config: Config)
                  (implicit serializer: ISerializer): Future[Done] = eventualQueueConfig flatMap { q =>
     logger.info(s"Start consuming queue ${q.url} with ${serializer.getClass.getSimpleName} serializer")
     // Get configuration options
-    val waitTimeSeconds = config.as[Option[Int]](s"sqs.settings.${q.key}.waitTimeSeconds").getOrElse(defaultWaitTimeSeconds)
-    val maxBufferSize = config.as[Option[Int]](s"sqs.settings.${q.key}.maxBufferSize").getOrElse(defaultMaxBufferSize)
-    val maxBatchSize = config.as[Option[Int]](s"sqs.settings.${q.key}.maxBatchSize").getOrElse(defaultMaxBatchSize)
-    val maxRetries = config.as[Option[Int]](s"sqs.settings.${q.key}.maxRetries").getOrElse(defaultMaxRetries)
+    val waitTimeSeconds = Try(config.getInt(s"sqs.settings.${q.key}.waitTimeSeconds")).toOption.getOrElse(defaultWaitTimeSeconds)
+    val maxBufferSize = Try(config.getInt(s"sqs.settings.${q.key}.maxBufferSize")).toOption.getOrElse(defaultMaxBufferSize)
+    val maxBatchSize = Try(config.getInt(s"sqs.settings.${q.key}.maxBatchSize")).toOption.getOrElse(defaultMaxBatchSize)
+    val maxRetries = Try(config.getInt(s"sqs.settings.${q.key}.maxRetries")).toOption.getOrElse(defaultMaxRetries)
 
     // Configure source to send all attributes from the message
     val sqsSettings = new SqsSourceSettings(waitTimeSeconds, maxBufferSize, maxBatchSize,
@@ -108,6 +108,7 @@ class SqsClient @Inject()(config: Config)
               (implicit serializer: ISerializer): Future[SourceQueueWithComplete[(JsValue, Promise[Done])]] =
     eventualQueueConfig map { q =>
       val flow = SqsFlow(q.url)
-      Source.queue[(JsValue, Promise[Done])](0, OverflowStrategy.backpressure) to Producer.sqs(flow) run()
+      logger.info(s"Start producer for ${q.url}")
+      Source.queue[(JsValue, Promise[Done])](0, OverflowStrategy.backpressure).async to Producer.sqs(flow) run()
     }
 }

--- a/src/main/scala/com/taxis99/package.scala
+++ b/src/main/scala/com/taxis99/package.scala
@@ -1,0 +1,18 @@
+package com
+
+import com.typesafe.config.Config
+
+import scala.util.Try
+
+package object taxis99 {
+  object implicits {
+
+    val DISABLE_BUFFER: Int = 0
+
+    implicit class OptionalConfiguration(config: Config) {
+      def getOptionalInt(path: String) = Try {
+        config.getInt(path)
+      }.toOption
+    }
+  }
+}

--- a/src/test/scala/com/taxis99/amazon/sqs/SqsClientSpec.scala
+++ b/src/test/scala/com/taxis99/amazon/sqs/SqsClientSpec.scala
@@ -4,7 +4,7 @@ import akka.Done
 import akka.testkit.TestProbe
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.taxis99.amazon.serializers.{ISerializer, PlayJson}
-import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import play.api.libs.json.Json
 import test.StreamSpec
 
@@ -15,10 +15,15 @@ class SqsClientSpec extends StreamSpec {
   implicit val serializer: ISerializer = PlayJson
 
   val (queueKey, queueName) = ("test-q", "test-q-DEV")
-  val config = ConfigFactory.empty()
-    .withValue("sqs", ConfigValueFactory.fromMap(Map(
-      queueKey -> queueName
-    ).asJava))
+  val config: Config = ConfigFactory.parseMap(Map[String, String](
+    s"sqs.$queueKey" -> queueName,
+    s"sqs.settings.default.waitTimeSeconds" -> "20",
+    s"sqs.settings.default.maxBufferSize" -> "100",
+    s"sqs.settings.default.maxBatchSize" -> "10",
+    s"sqs.settings.default.maxRetries" -> "200"
+  ).asJava)
+
+  println(config)
 
   def createQueue(queueName: String)(implicit aws: AmazonSQSAsync): String = {
     aws.createQueue(queueName).getQueueUrl

--- a/src/test/scala/com/taxis99/amazon/sqs/SqsClientSpec.scala
+++ b/src/test/scala/com/taxis99/amazon/sqs/SqsClientSpec.scala
@@ -23,8 +23,6 @@ class SqsClientSpec extends StreamSpec {
     s"sqs.settings.default.maxRetries" -> "200"
   ).asJava)
 
-  println(config)
-
   def createQueue(queueName: String)(implicit aws: AmazonSQSAsync): String = {
     aws.createQueue(queueName).getQueueUrl
   }


### PR DESCRIPTION
Set the producers to queue messages asynchronously instead of in a sequential fashion.
 
Akka optimizes the queue into a single thread without the `async` definition, causing the producer to fail upon receiving a lot of messages at the same time.

Refactor the configuration to use a more direct approach with a `resources.conf` and remove the external config lib.

Bump all important libs.